### PR TITLE
0.3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,12 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,26 +27,24 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap-utilities"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27149fe92e15009adc7ae78f0d7e6919e34afb4c9bc1273d1cf47019c9be79b5"
+checksum = "15bcff807ef65113605e59223ac0ce77adc2cc0976e3ece014e0f2c17e4a7798"
 dependencies = [
  "clap",
  "clap_complete",
@@ -62,18 +54,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.2.4"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4179da71abd56c26b54dd0c248cc081c1f43b0a1a7e8448e28e57a29baa993d"
+checksum = "11cba7abac9b56dfe2f035098cdb3a43946f276e6db83b72c4e692343f9aab9a"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -84,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -154,12 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,16 +167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897cd85af6387be149f55acf168e41be176a02de7872403aaab184afc2f327e6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -472,12 +448,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/crates/pretty-exec-lib/Cargo.toml
+++ b/crates/pretty-exec-lib/Cargo.toml
@@ -16,8 +16,8 @@ shell-escape = "^0.1.5"
 derive_more = "^0.99.17"
 typed-builder = "^0.10.0"
 thiserror = "^1.0.37"
-clap = { version = "3.2.22", features = ["derive"] }
-clap-utilities = "0.1.0"
+clap = { version = "4.0.15", features = ["derive"] }
+clap-utilities = "0.2.0"
 pipe-trait = "^0.4.0"
 
 [dev-dependencies]

--- a/crates/pretty-exec-lib/src/app.rs
+++ b/crates/pretty-exec-lib/src/app.rs
@@ -21,7 +21,7 @@ pub struct Param<'a> {
 
 pub fn main() -> Result<i32, Error> {
     let args = args::Args::parse();
-    let param = args.param();
+    let param = args.param()?;
 
     if param.skip_exec {
         print_title::print_title(param);

--- a/crates/pretty-exec-lib/src/app/args.rs
+++ b/crates/pretty-exec-lib/src/app/args.rs
@@ -4,7 +4,7 @@ pub use when::When;
 
 use super::super::log::syntax_highlight::SyntaxHighLight;
 use super::Param;
-use clap::Parser;
+use clap::{Parser, ValueHint};
 use is_terminal::IsTerminal;
 use std::{ffi::OsString, io::stderr};
 
@@ -12,11 +12,11 @@ use std::{ffi::OsString, io::stderr};
 #[clap(name = "pretty-exec", rename_all = "kebab", version)]
 pub struct Args {
     /// Program to execute
-    #[clap(name = "program")]
+    #[clap(name = "program", value_hint = ValueHint::CommandName)]
     program: OsString,
 
     /// Arguments to pass to program
-    #[clap(name = "arguments")]
+    #[clap(name = "arguments", value_hint = ValueHint::Unknown)]
     arguments: Vec<OsString>,
 
     /// Customize the prompt before the command.

--- a/crates/pretty-exec-lib/src/app/args.rs
+++ b/crates/pretty-exec-lib/src/app/args.rs
@@ -11,13 +11,9 @@ use std::{ffi::OsString, io::stderr};
 #[derive(Parser)]
 #[clap(name = "pretty-exec", rename_all = "kebab", version)]
 pub struct Args {
-    /// Program to execute
-    #[clap(name = "program", value_hint = ValueHint::CommandName)]
-    program: OsString,
-
-    /// Arguments to pass to program
-    #[clap(name = "arguments", value_hint = ValueHint::Unknown)]
-    arguments: Vec<OsString>,
+    /// Command to execute
+    #[clap(name = "command", value_hint = ValueHint::CommandWithArguments, trailing_var_arg = true)]
+    command: Vec<OsString>,
 
     /// Customize the prompt before the command.
     #[clap(long, default_value = "$")]
@@ -48,8 +44,8 @@ impl Args {
 
     pub fn param(&'_ self) -> Param<'_> {
         Param {
-            program: self.program.as_os_str(),
-            arguments: self.arguments.as_slice(),
+            program: self.command[0].as_os_str(),
+            arguments: &self.command[1..],
             prompt: self.prompt.as_str(),
             skip_exec: self.skip_exec,
             support_github_action: self.github_actions,

--- a/crates/pretty-exec-lib/src/app/args.rs
+++ b/crates/pretty-exec-lib/src/app/args.rs
@@ -2,7 +2,7 @@ pub mod when;
 
 pub use when::When;
 
-use super::super::log::syntax_highlight::SyntaxHighLight;
+use super::super::{error::Error, log::syntax_highlight::SyntaxHighLight};
 use super::Param;
 use clap::{Parser, ValueHint};
 use is_terminal::IsTerminal;
@@ -42,15 +42,19 @@ impl Args {
         .syntax_highlight()
     }
 
-    pub fn param(&'_ self) -> Param<'_> {
-        Param {
+    pub fn param(&'_ self) -> Result<Param<'_>, Error> {
+        if self.command.is_empty() {
+            return Err(Error::MissingProgram);
+        }
+
+        Ok(Param {
             program: self.command[0].as_os_str(),
             arguments: &self.command[1..],
             prompt: self.prompt.as_str(),
             skip_exec: self.skip_exec,
             support_github_action: self.github_actions,
             syntax_highlight: self.syntax_highlight(),
-        }
+        })
     }
 }
 

--- a/crates/pretty-exec-lib/src/app/args.rs
+++ b/crates/pretty-exec-lib/src/app/args.rs
@@ -16,7 +16,7 @@ pub struct Args {
     command: Vec<OsString>,
 
     /// Customize the prompt before the command.
-    #[clap(long, default_value = "$")]
+    #[clap(long, name = "prompt", default_value = "$")]
     prompt: String,
 
     /// Do not execute, print command only

--- a/crates/pretty-exec-lib/src/error.rs
+++ b/crates/pretty-exec-lib/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 
 #[derive(Debug, From, Error)]
 pub enum Error {
+    #[error("Program is not specified")]
+    MissingProgram,
     #[error("Failed to get status code")]
     StatusCodeAcquisitionFailure,
     #[error("{}", _0)]

--- a/crates/pretty-exec/tests/integration.rs
+++ b/crates/pretty-exec/tests/integration.rs
@@ -26,6 +26,21 @@ fn expected_colorful_title() -> String {
 }
 
 #[test]
+fn missing_program() {
+    let output = exe().output().unwrap();
+
+    let expected_stdout = String::new();
+    let expected_stderr = "ERROR: Program is not specified\n".to_string();
+    let actual_stderr = u8v_to_utf8(&output.stderr);
+    let actual_stdout = u8v_to_utf8(&output.stdout);
+
+    assert_eq!(
+        (actual_stderr, actual_stdout),
+        (expected_stderr, expected_stdout),
+    );
+}
+
+#[test]
 fn color_always() {
     let output = exe()
         .arg("--color=always")

--- a/exports/completion.bash
+++ b/exports/completion.bash
@@ -8,8 +8,8 @@ _pretty-exec() {
 
     for i in ${COMP_WORDS[@]}
     do
-        case "${i}" in
-            "$1")
+        case "${cmd},${i}" in
+            ",$1")
                 cmd="pretty__exec"
                 ;;
             *)
@@ -19,7 +19,7 @@ _pretty-exec() {
 
     case "${cmd}" in
         pretty__exec)
-            opts="-h -V --help --version --prompt --skip-exec --color --github-actions <program> <arguments>..."
+            opts="-h -V --prompt --skip-exec --color --github-actions --help --version <program> [arguments]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/exports/completion.bash
+++ b/exports/completion.bash
@@ -19,7 +19,7 @@ _pretty-exec() {
 
     case "${cmd}" in
         pretty__exec)
-            opts="-h -V --prompt --skip-exec --color --github-actions --help --version <program> [arguments]..."
+            opts="-h -V --prompt --skip-exec --color --github-actions --help --version [command]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/exports/completion.elv
+++ b/exports/completion.elv
@@ -20,12 +20,12 @@ set edit:completion:arg-completer[pretty-exec] = {|@words|
         &'pretty-exec'= {
             cand --prompt 'Customize the prompt before the command'
             cand --color 'When to use color'
+            cand --skip-exec 'Do not execute, print command only'
+            cand --github-actions 'Enable GitHub Action grouping'
             cand -h 'Print help information'
             cand --help 'Print help information'
             cand -V 'Print version information'
             cand --version 'Print version information'
-            cand --skip-exec 'Do not execute, print command only'
-            cand --github-actions 'Enable GitHub Action grouping'
         }
     ]
     $completions[$command]

--- a/exports/completion.fish
+++ b/exports/completion.fish
@@ -1,6 +1,6 @@
 complete -c pretty-exec -l prompt -d 'Customize the prompt before the command' -r
 complete -c pretty-exec -l color -d 'When to use color' -r -f -a "{auto	,never	,always	}"
-complete -c pretty-exec -s h -l help -d 'Print help information'
-complete -c pretty-exec -s V -l version -d 'Print version information'
 complete -c pretty-exec -l skip-exec -d 'Do not execute, print command only'
 complete -c pretty-exec -l github-actions -d 'Enable GitHub Action grouping'
+complete -c pretty-exec -s h -l help -d 'Print help information'
+complete -c pretty-exec -s V -l version -d 'Print version information'

--- a/exports/completion.ps1
+++ b/exports/completion.ps1
@@ -23,12 +23,12 @@ Register-ArgumentCompleter -Native -CommandName 'pretty-exec' -ScriptBlock {
         'pretty-exec' {
             [CompletionResult]::new('--prompt', 'prompt', [CompletionResultType]::ParameterName, 'Customize the prompt before the command')
             [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'When to use color')
+            [CompletionResult]::new('--skip-exec', 'skip-exec', [CompletionResultType]::ParameterName, 'Do not execute, print command only')
+            [CompletionResult]::new('--github-actions', 'github-actions', [CompletionResultType]::ParameterName, 'Enable GitHub Action grouping')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('--skip-exec', 'skip-exec', [CompletionResultType]::ParameterName, 'Do not execute, print command only')
-            [CompletionResult]::new('--github-actions', 'github-actions', [CompletionResultType]::ParameterName, 'Enable GitHub Action grouping')
             break
         }
     })

--- a/exports/completion.zsh
+++ b/exports/completion.zsh
@@ -23,8 +23,7 @@ _pretty-exec() {
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-':program -- Program to execute:_command_names -e' \
-'*::arguments -- Arguments to pass to program:' \
+'*::command -- Command to execute:_cmdambivalent' \
 && ret=0
 }
 

--- a/exports/completion.zsh
+++ b/exports/completion.zsh
@@ -17,12 +17,12 @@ _pretty-exec() {
     _arguments "${_arguments_options[@]}" \
 '--prompt=[Customize the prompt before the command]:PROMPT: ' \
 '--color=[When to use color]:color:(auto never always)' \
+'--skip-exec[Do not execute, print command only]' \
+'--github-actions[Enable GitHub Action grouping]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-'--skip-exec[Do not execute, print command only]' \
-'--github-actions[Enable GitHub Action grouping]' \
 ':program -- Program to execute:' \
 '*::arguments -- Arguments to pass to program:' \
 && ret=0

--- a/exports/completion.zsh
+++ b/exports/completion.zsh
@@ -23,7 +23,7 @@ _pretty-exec() {
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-':program -- Program to execute:' \
+':program -- Program to execute:_command_names -e' \
 '*::arguments -- Arguments to pass to program:' \
 && ret=0
 }

--- a/exports/completion.zsh
+++ b/exports/completion.zsh
@@ -15,7 +15,7 @@ _pretty-exec() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'--prompt=[Customize the prompt before the command]:PROMPT: ' \
+'--prompt=[Customize the prompt before the command]:prompt: ' \
 '--color=[When to use color]:color:(auto never always)' \
 '--skip-exec[Do not execute, print command only]' \
 '--github-actions[Enable GitHub Action grouping]' \


### PR DESCRIPTION
* Make `is_terminal` lazy to avoid unnecessary function calls
* Upgrade `clap` to `4.x`
* Improve ZSH completions with `value_hint = ValueHint::CommandWithArguments`